### PR TITLE
isWritableByCurrentUser is not part of systemsettings, remove it

### DIFF
--- a/SystemSettings.php
+++ b/SystemSettings.php
@@ -54,7 +54,6 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
             $field->title = $this->t('EnabledSettingTitle');
             $field->uiControl = FieldConfig::UI_CONTROL_CHECKBOX;
             $field->description = $this->t('EnabledSettingDescription');
-            $field->readableByCurrentUser = true;
         });
     }
 


### PR DESCRIPTION
Removing `isWritableByCurrentUser` for the field enabled, as the method doesn't exist on the object and we are getting this in the logs:

```php
plugins/AdminNotification/SystemSettings.php(57): Deprecated - Creation of dynamic property Piwik\Settings\FieldConfig::$readableByCurrentUser is deprecated - Matomo 5.2.1
```