### PR TITLE
make sure needed fields have values before saving

### DIFF
--- a/SystemSettings.php
+++ b/SystemSettings.php
@@ -89,6 +89,12 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
                 $field->uiControl = FieldConfig::UI_CONTROL_TEXT;
             //$field->uiControlAttributes = array("size"=> 65);
                 $field->description = $this->t('TitleSettingDescription');
+                $field->validate = function ($value) {
+                    $value = trim($value);
+                    if (strlen($value) == 0) {
+                        throw new \Exception($this->t('TitleMissing'));
+                    }
+                };
             }
         );
     }
@@ -100,6 +106,12 @@ class SystemSettings extends \Piwik\Settings\Plugin\SystemSettings
             $field->condition = 'enabled';
             $field->uiControl = FieldConfig::UI_CONTROL_TEXTAREA;
             $field->description = $this->t('MessageSettingDescription');
+            $field->validate = function ($value) {
+                $value = trim($value);
+                if (strlen($value) == 0) {
+                    throw new \Exception($this->t('MessageMissing'));
+                }
+            };
         });
     }
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -8,6 +8,8 @@
         "ContextSettingTitle": "Context",
         "ContextSettingDescription": "Sets what type of message should be displayed (affects color).",
         "TitleSettingTitle": "Title",
-        "TitleSettingDescription": "Sets the title of the message. This will be dislayed in bold with the message."
+        "TitleSettingDescription": "Sets the title of the message. This will be dislayed in bold with the message.",
+        "TitleMissing": "You must provide a title.",
+        "MessageMissing": "You must provide a message."
     }
 }


### PR DESCRIPTION
If you do not provide values for title or message, Matomo will throw an error when saving ("Could not save plugin settings"), this pull request checks so title and message is not empty on save.